### PR TITLE
Added event banner for SF Crypto Dev Meetup

### DIFF
--- a/src/views/index.html
+++ b/src/views/index.html
@@ -1,4 +1,13 @@
 <nav class="navbar navbar-default">
+  <div class="modal-strip" style="background-color: black; padding-top: 5px">
+    <div class="container">
+        <div class="row">
+            <div class="col-sm-12 overflow-hidden text-center">
+              <p style="color: orange"><strong>Presenting @ SF Cryptocurrency Devs Meetup</strong> Wednesday, February 21, 2017 <a href="https://www.meetup.com/SF-Cryptocurrency-Devs/events/246601051/" target="_blank"> RSVP HERE</a> </p>
+            </div>
+        </div>
+    </div>
+  </div>
   <div class="container-fluid">
     <!-- Brand and toggle get grouped for better mobile display -->
     <div class="navbar-header">

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -3,7 +3,7 @@
     <div class="container">
         <div class="row">
             <div class="col-sm-12 overflow-hidden text-center">
-              <p style="color: orange"><strong>Presenting @ SF Cryptocurrency Devs Meetup</strong> Wednesday, February 21, 2017 <a href="https://www.meetup.com/SF-Cryptocurrency-Devs/events/246601051/" target="_blank"> RSVP HERE</a> </p>
+              <p style="color: orange"><strong>Presenting @ SF Cryptocurrency Devs Meetup</strong> Wednesday, February 21, 2018 <a href="https://www.meetup.com/SF-Cryptocurrency-Devs/events/246601051/" target="_blank"> RSVP HERE</a> </p>
             </div>
         </div>
     </div>

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -3,7 +3,7 @@
     <div class="container">
         <div class="row">
             <div class="col-sm-12 overflow-hidden text-center">
-              <p style="color: orange"><strong>Presenting @ SF Cryptocurrency Devs Meetup</strong> Wednesday, February 21, 2018 <a href="https://www.meetup.com/SF-Cryptocurrency-Devs/events/246601051/" target="_blank"> RSVP HERE</a> </p>
+              <p style="color: orange"><strong>Bitcoin Private Seminar @ SF Cryptocurrency Devs Meetup</strong> Wednesday, February 21, 2018 <a href="https://www.meetup.com/SF-Cryptocurrency-Devs/events/246601051/" target="_blank"> RSVP HERE</a> </p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Added promotional banner at the top of the website promoting Bitcoin Private's exciting, upcoming presentation at the SF Crypto Dev's meetup Feb 21, 2018.

Here is a pic:

<img width="1439" alt="screen shot 2018-01-08 at 12 33 54 pm" src="https://user-images.githubusercontent.com/16689974/34691044-38fdc6fa-f470-11e7-82f1-b1905aae5f79.png">


  